### PR TITLE
Release 1.0.9 again

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,16 @@ Config has a following format:
 
 ## Releasing new versions
 
-In order to create a release, manully update the version in `package.json` of your feature branch.
-You can also use [`npm version`](https://docs.npmjs.com/cli/version) to do so.
+In order to create a release:
 
-Add details about changes in `Changelog.md`.
-
-New versions are automatically published to Gemfury on every merge to `master`.
+1. Update the version in `package.json` of your feature branch
+    1. You can also use [`npm version`](https://docs.npmjs.com/cli/version) to do so
+1. Add details about changes in `Changelog.md`
+1. Tag the last commit with the new version
+    1. `git tag v1.x.x`
+    1. `git push origin v1.x.x`
+1. Merge to master!
+    1. New versions are automatically published to Gemfury on every merge to `master`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -76,13 +76,14 @@ Config has a following format:
 In order to create a release:
 
 1. Add details about changes in `CHANGELOG.md`
-1. Manual version update:
-  1. Update the version in `package.json` of your feature branch
-  1. Tag the last commit with the new version
-      1. `git tag v1.x.x`
-      1. `git push origin v1.x.x`
-1. Automatic version update:
-  1. Use [`npm version`](https://docs.npmjs.com/cli/version)
+1. Version the new changes
+    - Manual version update:
+        1. Update the version in `package.json` of your feature branch
+        1. Tag the last commit with the new version
+            1. `git tag v1.x.x`
+            1. `git push origin v1.x.x`
+    - Automatic version update:
+        1. Use [`npm version`](https://docs.npmjs.com/cli/version)
 1. Merge to master!
     1. New versions are automatically published to Gemfury on every merge to `master`
 

--- a/README.md
+++ b/README.md
@@ -75,12 +75,14 @@ Config has a following format:
 
 In order to create a release:
 
-1. Update the version in `package.json` of your feature branch
-    1. You can also use [`npm version`](https://docs.npmjs.com/cli/version) to do so
-1. Add details about changes in `Changelog.md`
-1. Tag the last commit with the new version
-    1. `git tag v1.x.x`
-    1. `git push origin v1.x.x`
+1. Add details about changes in `CHANELOG.md`
+1. Manual version update:
+  1. Update the version in `package.json` of your feature branch
+  1. Tag the last commit with the new version
+      1. `git tag v1.x.x`
+      1. `git push origin v1.x.x`
+1. Automatic version update:
+  1. Use [`npm version`](https://docs.npmjs.com/cli/version)
 1. Merge to master!
     1. New versions are automatically published to Gemfury on every merge to `master`
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Config has a following format:
 
 In order to create a release:
 
-1. Add details about changes in `CHANELOG.md`
+1. Add details about changes in `CHANGELOG.md`
 1. Manual version update:
   1. Update the version in `package.json` of your feature branch
   1. Tag the last commit with the new version

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@
 
 export = Events;
 
-declare function Events(config: Events.Config): Events.emitEvent;
+declare function Events(config: Events.Config): Events.EmitEvent;
 
 declare namespace Events {
   interface Config {
@@ -22,5 +22,7 @@ declare namespace Events {
     [key: string]: unknown; // dependent on the specific event schema
   }
 
-  type emitEvent = (event: EventSchema) => AWS.Request<AWS.Kinesis.Types.PutRecordOutput, AWS.AWSError>;
+  type EmitEvent = (event: EventSchema) => ReturnType<
+    AWS.Request<AWS.Kinesis.Types.PutRecordOutput, AWS.AWSError>['promise']
+  >;
 }


### PR DESCRIPTION
https://github.com/babbel/miza-kinesis/pull/56 wasn't published to gem fury because it's a [requirement for a git tag to be present before merging to master](https://github.com/babbel/miza-kinesis/blob/master/.github/workflows/build.yml#L34). Therefore, I updated the instructions on it. 

Also, I had to fix some of the typings, so it's good to have a second chance to release. :)
