### PR TITLE
add user_agent and ip in order to fix internal validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ const config = {
     },
     maxRetries: 10
   },
-  ip: '127.0.0.1',
+  ip: '127.0.0.1', // optional
   endpoint: 'http://localhost:4568' // localstack only
 };
 
@@ -67,6 +67,7 @@ Config has a following format:
 * `kinesisStream.arn` - **required** Kinesis ARN where the events will be send
 * `kinesisStream.httpOptions` - *optional* specified in AWS SDK https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Kinesis.html
 * `kinesisStream.maxRetries` - **optional** the maximum amount of retries to attempt with a request. See AWS.Kinesis.maxRetries for more information.
+* `ip` - *optional* ip of the machine that is sending the event
 * `endpoint` - **localstack-only** we recommend to run the service in development environment using Localstack. Kinesis (from Localstack) will respond at the location `http://localhost:4568`. In order to work with Kinesis, you need to provide the location(endpoint) to the AWS-sdk configuration.
 * `partitionKey` - **optional** the key used to group data by shard within a stream.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ const config = {
     },
     maxRetries: 10
   },
+  ip: '127.0.0.1',
   endpoint: 'http://localhost:4568' // localstack only
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babbel/miza-kinesis",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "Library to emit Events to Kinesis Events Queue",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/event.js
+++ b/src/event.js
@@ -9,7 +9,7 @@ const partitionKey = (event) => (
   newHash(event) // fallback
 );
 
-const enrichMeta = (event, appName) => {
+const enrichMeta = (event, appName, ip) => {
   const createdAt = new Date().toISOString();
 
   const enrichedEvent = Object.assign({ created_at: createdAt }, event);
@@ -17,14 +17,16 @@ const enrichMeta = (event, appName) => {
   enrichedEvent.meta = Object.assign({
     created_at: createdAt,
     event_uuid: crypto.randomBytes(16).toString('hex'),
-    producer: appName
+    producer: appName,
+    user_agent: 'miza-kinesis',
+    ip
   }, enrichedEvent.meta);
 
   return enrichedEvent;
 };
 
 module.exports = (kinesis, event, config) => {
-  const enrichedEvent = enrichMeta(event, config.appName);
+  const enrichedEvent = enrichMeta(event, config.appName, config.ip);
 
   const params = {
     Data: JSON.stringify(enrichedEvent),

--- a/test/event.test.js
+++ b/test/event.test.js
@@ -56,8 +56,10 @@ describe('#emitEvent', () => {
         meta:
         { created_at: createdAt,
           event_uuid: EVENT_UUID_RESULT,
-          producer: 'some name' }
-        };
+          producer: 'some name',
+          user_agent: 'miza-kinesis'
+        }
+      };
 
         emitEvent(kinesis, event, config);
         expect(putRecordStub).to.have.been.calledWith({
@@ -95,8 +97,10 @@ describe('#emitEvent', () => {
         meta:
         { created_at: createdAt,
           event_uuid: EVENT_UUID_RESULT,
-          producer: 'test-app' }
-        };
+          producer: 'test-app',
+          user_agent: 'miza-kinesis'
+        },
+      };
 
         emitEvent(kinesis, event, config);
         expect(putRecordStub).to.have.been.calledWith({
@@ -124,8 +128,10 @@ describe('#emitEvent', () => {
           meta:
           { created_at: createdAt,
             event_uuid: EVENT_UUID_RESULT,
-            producer: 'test-app' }
-          };
+            producer: 'test-app',
+            user_agent: 'miza-kinesis' 
+          }
+        };
   
           emitEvent(kinesis, event, config);
           expect(putRecordStub).to.have.been.calledWith({


### PR DESCRIPTION
## Context
TNT is working on the event validation initiative and currently every consumer of miza-kinesis will fail the validation.
This is because the library is not reporting 2 meta tags that are required: user_agent and IP

## Changes proposed
- User agent will always be miza-kinesis
- Ip will be passed in the configuration as an optional parameter (you will be able to choose if sending a real ip or a fake one