### PR TITLE
fix: Require only Kinesis from AWS SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1]
+
+### Fixed
+
+- Fix require of Kinesis client
+
 ## [2.0.0]
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@babbel/miza-kinesis",
-  "version": "v2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babbel/miza-kinesis",
-  "version": "v2.0.0",
+  "version": "2.0.1",
   "description": "Library to emit Events to Kinesis Events Queue",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/kinesis.js
+++ b/src/kinesis.js
@@ -1,7 +1,7 @@
-const AWS = require("aws-sdk");
+const Kinesis = require("aws-sdk/clients/kinesis");
 
 module.exports = (streamConfig) =>
-  new AWS.Kinesis({
+  new Kinesis({
     region: streamConfig.region,
     httpOptions: streamConfig.httpOptions,
     maxRetries: streamConfig.maxRetries,


### PR DESCRIPTION
#### Description of change

It is unnecessary to require the entire AWS SDK for the library to
function. It adds unnecessary weight to the module, regardless
whether the dependant project uses a bundler or not

#### Checklist

- [ ] TypeScript definitions are up-to-date
