### PR TITLE
Fix batch emitting + update type declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [4.0.3]
+
+### Fixed
+- Use [`PutRecords`](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecords.html) instead of `PutRecord` when emitting events in batches, and return the output of operation in the settled Promise results
+- Send batch payloads as `Buffer` similar to when emitting a single event
+- Update type declarations after configuration changes in 4.x
+
 ## [4.0.2]
 
 ### Fix

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,9 @@
 // Type definitions for miza-kinesis
 // Project: Babbel
+import {
+  PutRecordCommandOutput,
+  PutRecordsResultEntry,
+} from "@aws-sdk/client-kinesis";
 
 export = Events;
 
@@ -12,7 +16,8 @@ declare namespace Events {
       arn: string;
       region?: string;
       maxRetries?: number;
-      httpOptions?: AWS.HTTPOptions;
+      timeout?: number;
+      connectionTimeout?: number;
     };
     endpoint?: string;
     partitionKey?: string;
@@ -25,12 +30,10 @@ declare namespace Events {
     [key: string]: unknown; // dependent on the specific event schema
   }
 
-  type EmitEvent = (
-    event: EventSchema | EventSchema[]
-  ) => ReturnType<
-    AWS.Request<
-      AWS.Kinesis.Types.PutRecordOutput | AWS.Kinesis.Types.PutRecordsOutput,
-      AWS.AWSError
-    >["promise"]
+  type EmitEvent = <T extends EventSchema>(
+    event: T | T[]
+  ) => Promise<
+    | PutRecordCommandOutput
+    | PromiseSettledResult<Awaited<PutRecordsResultEntry[]>>[]
   >;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@babbel/miza-kinesis",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babbel/miza-kinesis",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Library to emit Events to Kinesis Events Queue",
   "main": "index.js",
   "types": "index.d.ts",

--- a/test/integrations/emit_event.test.js
+++ b/test/integrations/emit_event.test.js
@@ -17,10 +17,14 @@ const event = {
   meta: {},
 };
 
-const emitEvent = events(config);
+let emitEvent;
 
 describe("emitEvent", () => {
   describe("emits one event", () => {
+    beforeEach(() => {
+      emitEvent = events(config);
+    });
+
     it("pushes an event to kinesis and finds it back", async () => {
       const data = await emitEvent(event);
       const rawKinesisData = await getEvents(data);
@@ -32,6 +36,33 @@ describe("emitEvent", () => {
     it("contains all the expected meta keys", async () => {
       const data = await emitEvent(event);
       const rawKinesisData = await getEvents(data);
+      const kinesisData = rawKinesisData.map((d) => Buffer.from(d).toString());
+      const eventFromKinesis = kinesisData.map(JSON.parse)[0];
+      const metaKeys = Object.keys(eventFromKinesis.meta);
+      ["created_at", "event_uuid", "producer", "user_agent", "ipv4"].forEach(
+        (expectedkey) => {
+          expect(metaKeys).to.contain(expectedkey);
+        }
+      );
+    });
+  });
+
+  describe("emits a batch of events", () => {
+    beforeEach(() => {
+      emitEvent = events({ ...config, type: "BATCH" });
+    });
+
+    it("pushes an event batch to kinesis and finds it back", async () => {
+      const [{ value }] = await emitEvent([event]);
+      const rawKinesisData = await getEvents(value[0]);
+      const kinesisData = rawKinesisData.map((d) => Buffer.from(d).toString());
+      const eventFromKinesis = kinesisData.map(JSON.parse)[0];
+      expect(eventFromKinesis.name).to.equal(event.name);
+    });
+
+    it("contains all the expected meta keys", async () => {
+      const [{ value }] = await emitEvent([event]);
+      const rawKinesisData = await getEvents(value[0]);
       const kinesisData = rawKinesisData.map((d) => Buffer.from(d).toString());
       const eventFromKinesis = kinesisData.map(JSON.parse)[0];
       const metaKeys = Object.keys(eventFromKinesis.meta);

--- a/test/unit/emitEventsInBatches.test.js
+++ b/test/unit/emitEventsInBatches.test.js
@@ -8,7 +8,7 @@ const putRecordsStub = sinon.spy();
 const { enrichMeta } = require("../../src/enrich");
 
 const emitEventsInBatches = proxyquire("../src/emitEventsInBatches", {
-  "@aws-sdk/client-kinesis": { PutRecordCommand: putRecordsStub },
+  "@aws-sdk/client-kinesis": { PutRecordsCommand: putRecordsStub },
 });
 
 const { expect } = require("chai");
@@ -49,7 +49,7 @@ describe("#emitEventsInBatches", () => {
       emitEventsInBatches(kinesis, events, config);
       expect(putRecordsStub).to.have.been.calledWith({
         Records: events.map((event) => ({
-          Data: JSON.stringify(enrichMeta(event, config.appName)),
+          Data: Buffer.from(JSON.stringify(enrichMeta(event, config.appName))),
           PartitionKey: EVENT_UUID_RESULT,
         })),
         StreamName: "test-stream",
@@ -80,7 +80,7 @@ describe("#emitEventsInBatches", () => {
       expect(putRecordsStub.args[0][0]).to.deep.equal({
         StreamName: "test-stream",
         Records: events.slice(0, 500).map((event) => ({
-          Data: JSON.stringify(enrichMeta(event, config.appName)),
+          Data: Buffer.from(JSON.stringify(enrichMeta(event, config.appName))),
           PartitionKey: EVENT_UUID_RESULT,
         })),
       });
@@ -88,7 +88,7 @@ describe("#emitEventsInBatches", () => {
       expect(putRecordsStub.args[1][0]).to.deep.equal({
         StreamName: "test-stream",
         Records: events.slice(500, 501).map((event) => ({
-          Data: JSON.stringify(enrichMeta(event, config.appName)),
+          Data: Buffer.from(JSON.stringify(enrichMeta(event, config.appName))),
           PartitionKey: EVENT_UUID_RESULT,
         })),
       });
@@ -181,7 +181,9 @@ describe("#emitEventsInBatches", () => {
         emitEventsInBatches(kinesis, events, configWithPartitionKey);
         expect(putRecordsStub).to.have.been.calledWith({
           Records: events.map((event) => ({
-            Data: JSON.stringify(enrichMeta(event, config.appName)),
+            Data: Buffer.from(
+              JSON.stringify(enrichMeta(event, config.appName))
+            ),
             PartitionKey: "uuid",
           })),
           StreamName: "test-stream",


### PR DESCRIPTION
#### Description of change

- Use [`PutRecords`](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecords.html) instead of `PutRecord` when emitting events in batches, and return the output of operation in the settled Promise results
- Send batch payloads as `Buffer` similar to when emitting a single event
- Update type declarations after configuration changes in 4.x

#### Checklist

- [x] TypeScript definitions are up-to-date
