### PR TITLE
chore: Replace deprecated http handler and update the kinesis client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [4.0.4]
+
+### Chore
+- Replace deprecated `@aws-sdk/node-http-handler` with `@smithy/node-http-handler`
+- Update `@aws-sdk/client-kinesis`
+
 ## [4.0.3]
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,1079 +65,862 @@
         "tslib": "^1.11.1"
       }
     },
-    "@aws-sdk/abort-controller": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.310.0.tgz",
-      "integrity": "sha512-v1zrRQxDLA1MdPim159Vx/CPHqsB4uybSxRi1CnfHO5ZjHryx3a5htW2gdGAykVCul40+yJXvfpufMrELVxH+g==",
-      "requires": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
     "@aws-sdk/client-kinesis": {
-      "version": "3.312.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kinesis/-/client-kinesis-3.312.0.tgz",
-      "integrity": "sha512-9kL12RL1vUhNgV9Bw1PFTcThtbInNp14quQvK9lSS50hMdN5527cETuvgyn+H2nGMFVowFapizyTcwyYVn+sxg==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kinesis/-/client-kinesis-3.370.0.tgz",
+      "integrity": "sha512-zhpSD6KMAmpNrtuYLrjc2K+xW6V23bE4G4ydaWxVvhgvGhLNuXbPnMm6nj2DMvlydp5A3lW6+rVDQcwdmM+Sug==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.312.0",
-        "@aws-sdk/config-resolver": "3.310.0",
-        "@aws-sdk/credential-provider-node": "3.310.0",
-        "@aws-sdk/eventstream-serde-browser": "3.310.0",
-        "@aws-sdk/eventstream-serde-config-resolver": "3.310.0",
-        "@aws-sdk/eventstream-serde-node": "3.310.0",
-        "@aws-sdk/fetch-http-handler": "3.310.0",
-        "@aws-sdk/hash-node": "3.310.0",
-        "@aws-sdk/invalid-dependency": "3.310.0",
-        "@aws-sdk/middleware-content-length": "3.310.0",
-        "@aws-sdk/middleware-endpoint": "3.310.0",
-        "@aws-sdk/middleware-host-header": "3.310.0",
-        "@aws-sdk/middleware-logger": "3.310.0",
-        "@aws-sdk/middleware-recursion-detection": "3.310.0",
-        "@aws-sdk/middleware-retry": "3.310.0",
-        "@aws-sdk/middleware-serde": "3.310.0",
-        "@aws-sdk/middleware-signing": "3.310.0",
-        "@aws-sdk/middleware-stack": "3.310.0",
-        "@aws-sdk/middleware-user-agent": "3.310.0",
-        "@aws-sdk/node-config-provider": "3.310.0",
-        "@aws-sdk/node-http-handler": "3.310.0",
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/smithy-client": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/url-parser": "3.310.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.310.0",
-        "@aws-sdk/util-defaults-mode-node": "3.310.0",
-        "@aws-sdk/util-endpoints": "3.310.0",
-        "@aws-sdk/util-retry": "3.310.0",
-        "@aws-sdk/util-user-agent-browser": "3.310.0",
-        "@aws-sdk/util-user-agent-node": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "@aws-sdk/util-waiter": "3.310.0",
+        "@aws-sdk/client-sts": "3.370.0",
+        "@aws-sdk/credential-provider-node": "3.370.0",
+        "@aws-sdk/middleware-host-header": "3.370.0",
+        "@aws-sdk/middleware-logger": "3.370.0",
+        "@aws-sdk/middleware-recursion-detection": "3.370.0",
+        "@aws-sdk/middleware-signing": "3.370.0",
+        "@aws-sdk/middleware-user-agent": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@aws-sdk/util-endpoints": "3.370.0",
+        "@aws-sdk/util-user-agent-browser": "3.370.0",
+        "@aws-sdk/util-user-agent-node": "3.370.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/eventstream-serde-browser": "^1.0.1",
+        "@smithy/eventstream-serde-config-resolver": "^1.0.1",
+        "@smithy/eventstream-serde-node": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.2",
+        "@smithy/middleware-retry": "^1.0.3",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/smithy-client": "^1.0.3",
+        "@smithy/types": "^1.1.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.3",
+        "@smithy/util-utf8": "^1.0.1",
+        "@smithy/util-waiter": "^1.0.1",
         "tslib": "^2.5.0"
       },
       "dependencies": {
+        "@smithy/abort-controller": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.1.0.tgz",
+          "integrity": "sha512-5imgGUlZL4dW4YWdMYAKLmal9ny/tlenM81QZY7xYyb76z9Z/QOg7oM5Ak9HQl8QfFTlGVWwcMXl+54jroRgEQ==",
+          "requires": {
+            "@smithy/types": "^1.2.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/node-http-handler": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.1.0.tgz",
+          "integrity": "sha512-d3kRriEgaIiGXLziAM8bjnaLn1fthCJeTLZIwEIpzQqe6yPX0a+yQoLCTyjb2fvdLwkMoG4p7THIIB5cj5lkbg==",
+          "requires": {
+            "@smithy/abort-controller": "^1.1.0",
+            "@smithy/protocol-http": "^1.2.0",
+            "@smithy/querystring-builder": "^1.1.0",
+            "@smithy/types": "^1.2.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/protocol-http": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.2.0.tgz",
+          "integrity": "sha512-GfGfruksi3nXdFok5RhgtOnWe5f6BndzYfmEXISD+5gAGdayFGpjWu5pIqIweTudMtse20bGbc+7MFZXT1Tb8Q==",
+          "requires": {
+            "@smithy/types": "^1.2.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/querystring-builder": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.1.0.tgz",
+          "integrity": "sha512-gDEi4LxIGLbdfjrjiY45QNbuDmpkwh9DX4xzrR2AzjjXpxwGyfSpbJaYhXARw9p17VH0h9UewnNQXNwaQyYMDA==",
+          "requires": {
+            "@smithy/types": "^1.2.0",
+            "@smithy/util-uri-escape": "^1.1.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/util-uri-escape": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.1.0.tgz",
+          "integrity": "sha512-/jL/V1xdVRt5XppwiaEU8Etp5WHZj609n0xMTuehmCqdoOFbId1M+aEeDWZsQ+8JbEB/BJ6ynY2SlYmOaKtt8w==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
         "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
         }
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.310.0.tgz",
-      "integrity": "sha512-netFap3Mp9I7bzAjsswHPA5WEbQtNMmXvW9/IVb7tmf85/esXCWindtyI43e/Xerut9ZVyEACPBFn30CLLE2xQ==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.370.0.tgz",
+      "integrity": "sha512-0Ty1iHuzNxMQtN7nahgkZr4Wcu1XvqGfrQniiGdKKif9jG/4elxsQPiydRuQpFqN6b+bg7wPP7crFP1uTxx2KQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.310.0",
-        "@aws-sdk/fetch-http-handler": "3.310.0",
-        "@aws-sdk/hash-node": "3.310.0",
-        "@aws-sdk/invalid-dependency": "3.310.0",
-        "@aws-sdk/middleware-content-length": "3.310.0",
-        "@aws-sdk/middleware-endpoint": "3.310.0",
-        "@aws-sdk/middleware-host-header": "3.310.0",
-        "@aws-sdk/middleware-logger": "3.310.0",
-        "@aws-sdk/middleware-recursion-detection": "3.310.0",
-        "@aws-sdk/middleware-retry": "3.310.0",
-        "@aws-sdk/middleware-serde": "3.310.0",
-        "@aws-sdk/middleware-stack": "3.310.0",
-        "@aws-sdk/middleware-user-agent": "3.310.0",
-        "@aws-sdk/node-config-provider": "3.310.0",
-        "@aws-sdk/node-http-handler": "3.310.0",
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/smithy-client": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/url-parser": "3.310.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.310.0",
-        "@aws-sdk/util-defaults-mode-node": "3.310.0",
-        "@aws-sdk/util-endpoints": "3.310.0",
-        "@aws-sdk/util-retry": "3.310.0",
-        "@aws-sdk/util-user-agent-browser": "3.310.0",
-        "@aws-sdk/util-user-agent-node": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.370.0",
+        "@aws-sdk/middleware-logger": "3.370.0",
+        "@aws-sdk/middleware-recursion-detection": "3.370.0",
+        "@aws-sdk/middleware-user-agent": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@aws-sdk/util-endpoints": "3.370.0",
+        "@aws-sdk/util-user-agent-browser": "3.370.0",
+        "@aws-sdk/util-user-agent-node": "3.370.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.2",
+        "@smithy/middleware-retry": "^1.0.3",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/smithy-client": "^1.0.3",
+        "@smithy/types": "^1.1.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.3",
+        "@smithy/util-utf8": "^1.0.1",
         "tslib": "^2.5.0"
       },
       "dependencies": {
+        "@smithy/abort-controller": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.1.0.tgz",
+          "integrity": "sha512-5imgGUlZL4dW4YWdMYAKLmal9ny/tlenM81QZY7xYyb76z9Z/QOg7oM5Ak9HQl8QfFTlGVWwcMXl+54jroRgEQ==",
+          "requires": {
+            "@smithy/types": "^1.2.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/node-http-handler": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.1.0.tgz",
+          "integrity": "sha512-d3kRriEgaIiGXLziAM8bjnaLn1fthCJeTLZIwEIpzQqe6yPX0a+yQoLCTyjb2fvdLwkMoG4p7THIIB5cj5lkbg==",
+          "requires": {
+            "@smithy/abort-controller": "^1.1.0",
+            "@smithy/protocol-http": "^1.2.0",
+            "@smithy/querystring-builder": "^1.1.0",
+            "@smithy/types": "^1.2.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/protocol-http": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.2.0.tgz",
+          "integrity": "sha512-GfGfruksi3nXdFok5RhgtOnWe5f6BndzYfmEXISD+5gAGdayFGpjWu5pIqIweTudMtse20bGbc+7MFZXT1Tb8Q==",
+          "requires": {
+            "@smithy/types": "^1.2.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/querystring-builder": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.1.0.tgz",
+          "integrity": "sha512-gDEi4LxIGLbdfjrjiY45QNbuDmpkwh9DX4xzrR2AzjjXpxwGyfSpbJaYhXARw9p17VH0h9UewnNQXNwaQyYMDA==",
+          "requires": {
+            "@smithy/types": "^1.2.0",
+            "@smithy/util-uri-escape": "^1.1.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/util-uri-escape": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.1.0.tgz",
+          "integrity": "sha512-/jL/V1xdVRt5XppwiaEU8Etp5WHZj609n0xMTuehmCqdoOFbId1M+aEeDWZsQ+8JbEB/BJ6ynY2SlYmOaKtt8w==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
         "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
         }
       }
     },
     "@aws-sdk/client-sso-oidc": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.310.0.tgz",
-      "integrity": "sha512-3GKaRSfMD3OiYWGa+qg5KvJw0nLV0Vu7zRiulLuKDvgmWw3SNJKn3frWlmq/bKFUKahLsV8zozbeJItxtKAD6g==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.370.0.tgz",
+      "integrity": "sha512-jAYOO74lmVXylQylqkPrjLzxvUnMKw476JCUTvCO6Q8nv3LzCWd76Ihgv/m9Q4M2Tbqi1iP2roVK5bstsXzEjA==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.310.0",
-        "@aws-sdk/fetch-http-handler": "3.310.0",
-        "@aws-sdk/hash-node": "3.310.0",
-        "@aws-sdk/invalid-dependency": "3.310.0",
-        "@aws-sdk/middleware-content-length": "3.310.0",
-        "@aws-sdk/middleware-endpoint": "3.310.0",
-        "@aws-sdk/middleware-host-header": "3.310.0",
-        "@aws-sdk/middleware-logger": "3.310.0",
-        "@aws-sdk/middleware-recursion-detection": "3.310.0",
-        "@aws-sdk/middleware-retry": "3.310.0",
-        "@aws-sdk/middleware-serde": "3.310.0",
-        "@aws-sdk/middleware-stack": "3.310.0",
-        "@aws-sdk/middleware-user-agent": "3.310.0",
-        "@aws-sdk/node-config-provider": "3.310.0",
-        "@aws-sdk/node-http-handler": "3.310.0",
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/smithy-client": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/url-parser": "3.310.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.310.0",
-        "@aws-sdk/util-defaults-mode-node": "3.310.0",
-        "@aws-sdk/util-endpoints": "3.310.0",
-        "@aws-sdk/util-retry": "3.310.0",
-        "@aws-sdk/util-user-agent-browser": "3.310.0",
-        "@aws-sdk/util-user-agent-node": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
+        "@aws-sdk/middleware-host-header": "3.370.0",
+        "@aws-sdk/middleware-logger": "3.370.0",
+        "@aws-sdk/middleware-recursion-detection": "3.370.0",
+        "@aws-sdk/middleware-user-agent": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@aws-sdk/util-endpoints": "3.370.0",
+        "@aws-sdk/util-user-agent-browser": "3.370.0",
+        "@aws-sdk/util-user-agent-node": "3.370.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.2",
+        "@smithy/middleware-retry": "^1.0.3",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/smithy-client": "^1.0.3",
+        "@smithy/types": "^1.1.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.3",
+        "@smithy/util-utf8": "^1.0.1",
         "tslib": "^2.5.0"
       },
       "dependencies": {
+        "@smithy/abort-controller": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.1.0.tgz",
+          "integrity": "sha512-5imgGUlZL4dW4YWdMYAKLmal9ny/tlenM81QZY7xYyb76z9Z/QOg7oM5Ak9HQl8QfFTlGVWwcMXl+54jroRgEQ==",
+          "requires": {
+            "@smithy/types": "^1.2.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/node-http-handler": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.1.0.tgz",
+          "integrity": "sha512-d3kRriEgaIiGXLziAM8bjnaLn1fthCJeTLZIwEIpzQqe6yPX0a+yQoLCTyjb2fvdLwkMoG4p7THIIB5cj5lkbg==",
+          "requires": {
+            "@smithy/abort-controller": "^1.1.0",
+            "@smithy/protocol-http": "^1.2.0",
+            "@smithy/querystring-builder": "^1.1.0",
+            "@smithy/types": "^1.2.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/protocol-http": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.2.0.tgz",
+          "integrity": "sha512-GfGfruksi3nXdFok5RhgtOnWe5f6BndzYfmEXISD+5gAGdayFGpjWu5pIqIweTudMtse20bGbc+7MFZXT1Tb8Q==",
+          "requires": {
+            "@smithy/types": "^1.2.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/querystring-builder": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.1.0.tgz",
+          "integrity": "sha512-gDEi4LxIGLbdfjrjiY45QNbuDmpkwh9DX4xzrR2AzjjXpxwGyfSpbJaYhXARw9p17VH0h9UewnNQXNwaQyYMDA==",
+          "requires": {
+            "@smithy/types": "^1.2.0",
+            "@smithy/util-uri-escape": "^1.1.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/util-uri-escape": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.1.0.tgz",
+          "integrity": "sha512-/jL/V1xdVRt5XppwiaEU8Etp5WHZj609n0xMTuehmCqdoOFbId1M+aEeDWZsQ+8JbEB/BJ6ynY2SlYmOaKtt8w==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
         "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
         }
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.312.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.312.0.tgz",
-      "integrity": "sha512-t0U7vRvWaMjrzBUo6tPrHe6HE97Blqx+b4GOjFbcbLtzxLlcRfhnWJik0Lp8hJtVqzNoN5mL4OeYgK7CRpL/Sw==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.370.0.tgz",
+      "integrity": "sha512-utFxOPWIzbN+3kc415Je2o4J72hOLNhgR2Gt5EnRSggC3yOnkC4GzauxG8n7n5gZGBX45eyubHyPOXLOIyoqQA==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.310.0",
-        "@aws-sdk/credential-provider-node": "3.310.0",
-        "@aws-sdk/fetch-http-handler": "3.310.0",
-        "@aws-sdk/hash-node": "3.310.0",
-        "@aws-sdk/invalid-dependency": "3.310.0",
-        "@aws-sdk/middleware-content-length": "3.310.0",
-        "@aws-sdk/middleware-endpoint": "3.310.0",
-        "@aws-sdk/middleware-host-header": "3.310.0",
-        "@aws-sdk/middleware-logger": "3.310.0",
-        "@aws-sdk/middleware-recursion-detection": "3.310.0",
-        "@aws-sdk/middleware-retry": "3.310.0",
-        "@aws-sdk/middleware-sdk-sts": "3.310.0",
-        "@aws-sdk/middleware-serde": "3.310.0",
-        "@aws-sdk/middleware-signing": "3.310.0",
-        "@aws-sdk/middleware-stack": "3.310.0",
-        "@aws-sdk/middleware-user-agent": "3.310.0",
-        "@aws-sdk/node-config-provider": "3.310.0",
-        "@aws-sdk/node-http-handler": "3.310.0",
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/smithy-client": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/url-parser": "3.310.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "@aws-sdk/util-body-length-browser": "3.310.0",
-        "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.310.0",
-        "@aws-sdk/util-defaults-mode-node": "3.310.0",
-        "@aws-sdk/util-endpoints": "3.310.0",
-        "@aws-sdk/util-retry": "3.310.0",
-        "@aws-sdk/util-user-agent-browser": "3.310.0",
-        "@aws-sdk/util-user-agent-node": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "fast-xml-parser": "4.1.2",
+        "@aws-sdk/credential-provider-node": "3.370.0",
+        "@aws-sdk/middleware-host-header": "3.370.0",
+        "@aws-sdk/middleware-logger": "3.370.0",
+        "@aws-sdk/middleware-recursion-detection": "3.370.0",
+        "@aws-sdk/middleware-sdk-sts": "3.370.0",
+        "@aws-sdk/middleware-signing": "3.370.0",
+        "@aws-sdk/middleware-user-agent": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@aws-sdk/util-endpoints": "3.370.0",
+        "@aws-sdk/util-user-agent-browser": "3.370.0",
+        "@aws-sdk/util-user-agent-node": "3.370.0",
+        "@smithy/config-resolver": "^1.0.1",
+        "@smithy/fetch-http-handler": "^1.0.1",
+        "@smithy/hash-node": "^1.0.1",
+        "@smithy/invalid-dependency": "^1.0.1",
+        "@smithy/middleware-content-length": "^1.0.1",
+        "@smithy/middleware-endpoint": "^1.0.2",
+        "@smithy/middleware-retry": "^1.0.3",
+        "@smithy/middleware-serde": "^1.0.1",
+        "@smithy/middleware-stack": "^1.0.1",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/node-http-handler": "^1.0.2",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/smithy-client": "^1.0.3",
+        "@smithy/types": "^1.1.0",
+        "@smithy/url-parser": "^1.0.1",
+        "@smithy/util-base64": "^1.0.1",
+        "@smithy/util-body-length-browser": "^1.0.1",
+        "@smithy/util-body-length-node": "^1.0.1",
+        "@smithy/util-defaults-mode-browser": "^1.0.1",
+        "@smithy/util-defaults-mode-node": "^1.0.1",
+        "@smithy/util-retry": "^1.0.3",
+        "@smithy/util-utf8": "^1.0.1",
+        "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       },
       "dependencies": {
+        "@smithy/abort-controller": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.1.0.tgz",
+          "integrity": "sha512-5imgGUlZL4dW4YWdMYAKLmal9ny/tlenM81QZY7xYyb76z9Z/QOg7oM5Ak9HQl8QfFTlGVWwcMXl+54jroRgEQ==",
+          "requires": {
+            "@smithy/types": "^1.2.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/node-http-handler": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.1.0.tgz",
+          "integrity": "sha512-d3kRriEgaIiGXLziAM8bjnaLn1fthCJeTLZIwEIpzQqe6yPX0a+yQoLCTyjb2fvdLwkMoG4p7THIIB5cj5lkbg==",
+          "requires": {
+            "@smithy/abort-controller": "^1.1.0",
+            "@smithy/protocol-http": "^1.2.0",
+            "@smithy/querystring-builder": "^1.1.0",
+            "@smithy/types": "^1.2.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/protocol-http": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.2.0.tgz",
+          "integrity": "sha512-GfGfruksi3nXdFok5RhgtOnWe5f6BndzYfmEXISD+5gAGdayFGpjWu5pIqIweTudMtse20bGbc+7MFZXT1Tb8Q==",
+          "requires": {
+            "@smithy/types": "^1.2.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/querystring-builder": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.1.0.tgz",
+          "integrity": "sha512-gDEi4LxIGLbdfjrjiY45QNbuDmpkwh9DX4xzrR2AzjjXpxwGyfSpbJaYhXARw9p17VH0h9UewnNQXNwaQyYMDA==",
+          "requires": {
+            "@smithy/types": "^1.2.0",
+            "@smithy/util-uri-escape": "^1.1.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/util-uri-escape": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.1.0.tgz",
+          "integrity": "sha512-/jL/V1xdVRt5XppwiaEU8Etp5WHZj609n0xMTuehmCqdoOFbId1M+aEeDWZsQ+8JbEB/BJ6ynY2SlYmOaKtt8w==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
         "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/config-resolver": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.310.0.tgz",
-      "integrity": "sha512-8vsT+/50lOqfDxka9m/rRt6oxv1WuGZoP8oPMk0Dt+TxXMbAzf4+rejBgiB96wshI1k3gLokYRjSQZn+dDtT8g==",
-      "requires": {
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-config-provider": "3.310.0",
-        "@aws-sdk/util-middleware": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
         }
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.310.0.tgz",
-      "integrity": "sha512-vvIPQpI16fj95xwS7M3D48F7QhZJBnnCgB5lR+b7So+vsG9ibm1mZRVGzVpdxCvgyOhHFbvrby9aalNJmmIP1A==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.370.0.tgz",
+      "integrity": "sha512-raR3yP/4GGbKFRPP5hUBNkEmTnzxI9mEc2vJAJrcv4G4J4i/UP6ELiLInQ5eO2/VcV/CeKGZA3t7d1tsJ+jhCg==",
       "requires": {
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
         "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/credential-provider-imds": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.310.0.tgz",
-      "integrity": "sha512-baxK7Zp6dai5AGW01FIW27xS2KAaPUmKLIXv5SvFYsUgXXvNW55im4uG3b+2gA0F7V+hXvVBH08OEqmwW6we5w==",
-      "requires": {
-        "@aws-sdk/node-config-provider": "3.310.0",
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/url-parser": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
         }
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.310.0.tgz",
-      "integrity": "sha512-gtRz7I+4BBpwZ3tc6UIt5lQuiAFnkpOibxHh95x1M6HDxBjm+uqD6RPZYVH+dULZPYXOtOTsHV0IGjrcV0sSRg==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.370.0.tgz",
+      "integrity": "sha512-eJyapFKa4NrC9RfTgxlXnXfS9InG/QMEUPPVL+VhG7YS6nKqetC1digOYgivnEeu+XSKE0DJ7uZuXujN2Y7VAQ==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.310.0",
-        "@aws-sdk/credential-provider-imds": "3.310.0",
-        "@aws-sdk/credential-provider-process": "3.310.0",
-        "@aws-sdk/credential-provider-sso": "3.310.0",
-        "@aws-sdk/credential-provider-web-identity": "3.310.0",
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/shared-ini-file-loader": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/credential-provider-env": "3.370.0",
+        "@aws-sdk/credential-provider-process": "3.370.0",
+        "@aws-sdk/credential-provider-sso": "3.370.0",
+        "@aws-sdk/credential-provider-web-identity": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/credential-provider-imds": "^1.0.1",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
         "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
         }
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.310.0.tgz",
-      "integrity": "sha512-FrOztUcOq2Sp32xGtJvxfvdlmuAeoxIu/AElHzV1bkx6Pzo9DkQBhXrSQ+JFSpI++weOD4ZGFhAvgbgUOT4VAg==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.370.0.tgz",
+      "integrity": "sha512-gkFiotBFKE4Fcn8CzQnMeab9TAR06FEAD02T4ZRYW1xGrBJOowmje9dKqdwQFHSPgnWAP+8HoTA8iwbhTLvjNA==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.310.0",
-        "@aws-sdk/credential-provider-imds": "3.310.0",
-        "@aws-sdk/credential-provider-ini": "3.310.0",
-        "@aws-sdk/credential-provider-process": "3.310.0",
-        "@aws-sdk/credential-provider-sso": "3.310.0",
-        "@aws-sdk/credential-provider-web-identity": "3.310.0",
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/shared-ini-file-loader": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/credential-provider-env": "3.370.0",
+        "@aws-sdk/credential-provider-ini": "3.370.0",
+        "@aws-sdk/credential-provider-process": "3.370.0",
+        "@aws-sdk/credential-provider-sso": "3.370.0",
+        "@aws-sdk/credential-provider-web-identity": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/credential-provider-imds": "^1.0.1",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
         "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
         }
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.310.0.tgz",
-      "integrity": "sha512-h73sg6GPMUWC+3zMCbA1nZ2O03nNJt7G96JdmnantiXBwHpRKWW8nBTLzx5uhXn6hTuTaoQRP/P+oxQJKYdMmA==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.370.0.tgz",
+      "integrity": "sha512-0BKFFZmUO779Xdw3u7wWnoWhYA4zygxJbgGVSyjkOGBvdkbPSTTcdwT1KFkaQy2kOXYeZPl+usVVRXs+ph4ejg==",
       "requires": {
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/shared-ini-file-loader": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
         "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
         }
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.310.0.tgz",
-      "integrity": "sha512-nXkpT8mrM/wRqSiz/a4p9U2UrOKyfZXhbPHIHyQj8K+uLjsYS+WPuH287J4A5Q57A6uarTrj5RjHmVeZVLaHmg==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.370.0.tgz",
+      "integrity": "sha512-PFroYm5hcPSfC/jkZnCI34QFL3I7WVKveVk6/F3fud/cnP8hp6YjA9NiTNbqdFSzsyoiN/+e5fZgNKih8vVPTA==",
       "requires": {
-        "@aws-sdk/client-sso": "3.310.0",
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/shared-ini-file-loader": "3.310.0",
-        "@aws-sdk/token-providers": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/client-sso": "3.370.0",
+        "@aws-sdk/token-providers": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
         "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
         }
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.310.0.tgz",
-      "integrity": "sha512-H4SzuZXILNhK6/IR1uVvsUDZvzc051hem7GLyYghBCu8mU+tq28YhKE8MfSroi6eL2e5Vujloij1OM2EQQkPkw==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.370.0.tgz",
+      "integrity": "sha512-CFaBMLRudwhjv1sDzybNV93IaT85IwS+L8Wq6VRMa0mro1q9rrWsIZO811eF+k0NEPfgU1dLH+8Vc2qhw4SARQ==",
       "requires": {
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
         "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/eventstream-codec": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.310.0.tgz",
-      "integrity": "sha512-clIeSgWbZbxwtsxZ/yoedNM0/kJFSIjjHPikuDGhxhqc+vP6TN3oYyVMFrYwFaTFhk2+S5wZcWYMw8Op1pWo+A==",
-      "requires": {
-        "@aws-crypto/crc32": "3.0.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/eventstream-serde-browser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.310.0.tgz",
-      "integrity": "sha512-3S6ziuQVALgEyz0TANGtYDVeG8ArK4Y05mcgrs8qUTmsvlDIXX37cR/DvmVbNB76M4IrsZeSAIajL9644CywkA==",
-      "requires": {
-        "@aws-sdk/eventstream-serde-universal": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/eventstream-serde-config-resolver": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.310.0.tgz",
-      "integrity": "sha512-8s1Qdn9STj+sV75nUp9yt0W6fHS4BZ2jTm4Z/1Pcbvh2Gqs0WjH5n2StS+pDW5Y9J/HSGBl0ogmUr5lC5bXFHg==",
-      "requires": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/eventstream-serde-node": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.310.0.tgz",
-      "integrity": "sha512-kSnRomCgW43K9TmQYuwN9+AoYPnhyOKroanUMyZEzJk7rpCPMj4OzaUpXfDYOvznFNYn7NLaH6nHLJAr0VPlJA==",
-      "requires": {
-        "@aws-sdk/eventstream-serde-universal": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/eventstream-serde-universal": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.310.0.tgz",
-      "integrity": "sha512-Qyjt5k/waV5cDukpgT824ISZAz5U0pwzLz5ztR409u85AGNkF/9n7MS+LSyBUBSb0WJ5pUeSD47WBk+nLq9Nhw==",
-      "requires": {
-        "@aws-sdk/eventstream-codec": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/fetch-http-handler": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.310.0.tgz",
-      "integrity": "sha512-Bi9vIwzdkw1zMcvi/zGzlWS9KfIEnAq4NNhsnCxbQ4OoIRU9wvU+WGZdBBhxg0ZxZmpp1j1aZhU53lLjA07MHw==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/querystring-builder": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-base64": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/hash-node": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.310.0.tgz",
-      "integrity": "sha512-NvE2fhRc8GRwCXBfDehxVAWCmVwVMILliAKVPAEr4yz2CkYs0tqU51S48x23dtna07H4qHtgpeNqVTthcIQOEQ==",
-      "requires": {
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/invalid-dependency": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.310.0.tgz",
-      "integrity": "sha512-1s5RG5rSPXoa/aZ/Kqr5U/7lqpx+Ry81GprQ2bxWqJvWQIJ0IRUwo5pk8XFxbKVr/2a+4lZT/c3OGoBOM1yRRA==",
-      "requires": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/is-array-buffer": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
-      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-      "requires": {
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/middleware-content-length": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.310.0.tgz",
-      "integrity": "sha512-P8tQZxgDt6CAh1wd/W6WPzjc+uWPJwQkm+F7rAwRlM+k9q17HrhnksGDKcpuuLyIhPQYdmOMIkpKVgXGa4avhQ==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/middleware-endpoint": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.310.0.tgz",
-      "integrity": "sha512-Z+N2vOL8K354/lstkClxLLsr6hCpVRh+0tCMXrVj66/NtKysCEZ/0b9LmqOwD9pWHNiI2mJqXwY0gxNlKAroUg==",
-      "requires": {
-        "@aws-sdk/middleware-serde": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/url-parser": "3.310.0",
-        "@aws-sdk/util-middleware": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
         }
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.310.0.tgz",
-      "integrity": "sha512-QWSA+46/hXorXyWa61ic2K7qZzwHTiwfk2e9mRRjeIRepUgI3qxFjsYqrWtrOGBjmFmq0pYIY8Bb/DCJuQqcoA==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.370.0.tgz",
+      "integrity": "sha512-CPXOm/TnOFC7KyXcJglICC7OiA7Kj6mT3ChvEijr56TFOueNHvJdV4aNIFEQy0vGHOWtY12qOWLNto/wYR1BAQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "dependencies": {
+        "@smithy/protocol-http": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.2.0.tgz",
+          "integrity": "sha512-GfGfruksi3nXdFok5RhgtOnWe5f6BndzYfmEXISD+5gAGdayFGpjWu5pIqIweTudMtse20bGbc+7MFZXT1Tb8Q==",
+          "requires": {
+            "@smithy/types": "^1.2.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
         "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
         }
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.310.0.tgz",
-      "integrity": "sha512-Lurm8XofrASBRnAVtiSNuDSRsRqPNg27RIFLLsLp/pqog9nFJ0vz0kgdb9S5Z+zw83Mm+UlqOe6D8NTUNp4fVg==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.370.0.tgz",
+      "integrity": "sha512-cQMq9SaZ/ORmTJPCT6VzMML7OxFdQzNkhMAgKpTDl+tdPWynlHF29E5xGoSzROnThHlQPCjogU0NZ8AxI0SWPA==",
       "requires": {
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
         "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
         }
       }
     },
     "@aws-sdk/middleware-recursion-detection": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.310.0.tgz",
-      "integrity": "sha512-SuB75/xk/gyue24gkriTwO2jFd7YcUGZDClQYuRejgbXSa3CO0lWyawQtfLcSSEBp9izrEVXuFH24K1eAft5nQ==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.370.0.tgz",
+      "integrity": "sha512-L7ZF/w0lAAY/GK1khT8VdoU0XB7nWHk51rl/ecAg64J70dHnMOAg8n+5FZ9fBu/xH1FwUlHOkwlodJOgzLJjtg==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/middleware-retry": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.310.0.tgz",
-      "integrity": "sha512-oTPsRy2W4s+dfxbJPW7Km+hHtv/OMsNsVfThAq8DDYKC13qlr1aAyOqGLD+dpBy2aKe7ss517Sy2HcHtHqm7/g==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/service-error-classification": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-middleware": "3.310.0",
-        "@aws-sdk/util-retry": "3.310.0",
-        "tslib": "^2.5.0",
-        "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        "@smithy/protocol-http": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.2.0.tgz",
+          "integrity": "sha512-GfGfruksi3nXdFok5RhgtOnWe5f6BndzYfmEXISD+5gAGdayFGpjWu5pIqIweTudMtse20bGbc+7MFZXT1Tb8Q==",
+          "requires": {
+            "@smithy/types": "^1.2.0",
+            "tslib": "^2.5.0"
+          }
         },
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
         }
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.310.0.tgz",
-      "integrity": "sha512-+5PFwlYNLvLLIfw0ASAoWV/iIF8Zv6R6QGtyP0CclhRSvNjgbQDVnV0g95MC5qvh+GB/Yjlkt8qAjLSPjHfsrQ==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.370.0.tgz",
+      "integrity": "sha512-ykbsoVy0AJtVbuhAlTAMcaz/tCE3pT8nAp0L7CQQxSoanRCvOux7au0KwMIQVhxgnYid4dWVF6d00SkqU5MXRA==",
       "requires": {
-        "@aws-sdk/middleware-signing": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/middleware-signing": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
         "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/middleware-serde": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.310.0.tgz",
-      "integrity": "sha512-RNeeTVWSLTaentUeCgQKZhAl+C6hxtwD78cQWS10UymWpQFwbaxztzKUu4UQS5xA2j6PxwPRRUjqa4jcFjfLsg==",
-      "requires": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
         }
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.310.0.tgz",
-      "integrity": "sha512-f9mKq+XMdW207Af3hKjdTnpNhdtwqWuvFs/ZyXoOkp/g1MY1O6L23Jy6i52m29LxbT4AuNRG1oKODfXM0vYVjQ==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.370.0.tgz",
+      "integrity": "sha512-Dwr/RTCWOXdm394wCwICGT2VNOTMRe4IGPsBRJAsM24pm+EEqQzSS3Xu/U/zF4exuxqpMta4wec4QpSarPNTxA==",
       "requires": {
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/signature-v4": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-middleware": "3.310.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/signature-v4": "^1.0.1",
+        "@smithy/types": "^1.1.0",
+        "@smithy/util-middleware": "^1.0.1",
         "tslib": "^2.5.0"
       },
       "dependencies": {
+        "@smithy/protocol-http": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.2.0.tgz",
+          "integrity": "sha512-GfGfruksi3nXdFok5RhgtOnWe5f6BndzYfmEXISD+5gAGdayFGpjWu5pIqIweTudMtse20bGbc+7MFZXT1Tb8Q==",
+          "requires": {
+            "@smithy/types": "^1.2.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
         "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/middleware-stack": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.310.0.tgz",
-      "integrity": "sha512-010O1PD+UAcZVKRvqEusE1KJqN96wwrf6QsqbRM0ywsKQ21NDweaHvEDlds2VHpgmofxkRLRu/IDrlPkKRQrRg==",
-      "requires": {
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
         }
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.310.0.tgz",
-      "integrity": "sha512-x3IOwSwSbwKidlxRk3CNVHVUb06SRuaELxggCaR++QVI8NU6qD/l4VHXKVRvbTHiC/cYxXE/GaBDgQVpDR7V/g==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.370.0.tgz",
+      "integrity": "sha512-2+3SB6MtMAq1+gVXhw0Y3ONXuljorh6ijnxgTpv+uQnBW5jHCUiAS8WDYiDEm7i9euJPbvJfM8WUrSMDMU6Cog==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-endpoints": "3.310.0",
+        "@aws-sdk/types": "3.370.0",
+        "@aws-sdk/util-endpoints": "3.370.0",
+        "@smithy/protocol-http": "^1.1.0",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "dependencies": {
+        "@smithy/protocol-http": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.2.0.tgz",
+          "integrity": "sha512-GfGfruksi3nXdFok5RhgtOnWe5f6BndzYfmEXISD+5gAGdayFGpjWu5pIqIweTudMtse20bGbc+7MFZXT1Tb8Q==",
+          "requires": {
+            "@smithy/types": "^1.2.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
         "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/node-config-provider": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.310.0.tgz",
-      "integrity": "sha512-T/Pp6htc6hq/Cq+MLNDSyiwWCMVF6GqbBbXKVlO5L8rdHx4sq9xPdoPveZhGWrxvkanjA6eCwUp6E0riBOSVng==",
-      "requires": {
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/shared-ini-file-loader": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/node-http-handler": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.310.0.tgz",
-      "integrity": "sha512-irv9mbcM9xC2xYjArQF5SYmHBMu4ciMWtGsoHII1nRuFOl9FoT4ffTvEPuLlfC6pznzvKt9zvnm6xXj7gDChKg==",
-      "requires": {
-        "@aws-sdk/abort-controller": "3.310.0",
-        "@aws-sdk/protocol-http": "3.310.0",
-        "@aws-sdk/querystring-builder": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/property-provider": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.310.0.tgz",
-      "integrity": "sha512-3lxDb0akV6BBzmFe4nLPaoliQbAifyWJhuvuDOu7e8NzouvpQXs0275w9LePhhcgjKAEVXUIse05ZW2DLbxo/g==",
-      "requires": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/protocol-http": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.310.0.tgz",
-      "integrity": "sha512-fgZ1aw/irQtnrsR58pS8ThKOWo57Py3xX6giRvwSgZDEcxHfVzuQjy9yPuV++v04fdmdtgpbGf8WfvAAJ11yXQ==",
-      "requires": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/querystring-builder": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.310.0.tgz",
-      "integrity": "sha512-ZHH8GV/80+pWGo7DzsvwvXR5xVxUHXUvPJPFAkhr6nCf78igdoF8gR10ScFoEKbtEapoNTaZlKHPXxpD8aPG7A==",
-      "requires": {
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-uri-escape": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/querystring-parser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.310.0.tgz",
-      "integrity": "sha512-YkIznoP6lsiIUHinx++/lbb3tlMURGGqMpo0Pnn32zYzGrJXA6eC3D0as2EcMjo55onTfuLcIiX4qzXes2MYOA==",
-      "requires": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/service-error-classification": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.310.0.tgz",
-      "integrity": "sha512-PuyC7k3qfIKeH2LCnDwbttMOKq3qAx4buvg0yfnJtQOz6t1AR8gsnAq0CjKXXyfkXwNKWTqCpE6lVNUIkXgsMw=="
-    },
-    "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.310.0.tgz",
-      "integrity": "sha512-N0q9pG0xSjQwc690YQND5bofm+4nfUviQ/Ppgan2kU6aU0WUq8KwgHJBto/YEEI+VlrME30jZJnxtOvcZJc2XA==",
-      "requires": {
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/signature-v4": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.310.0.tgz",
-      "integrity": "sha512-1M60P1ZBNAjCFv9sYW29OF6okktaeibWyW3lMXqzoHF70lHBZh+838iUchznXUA5FLabfn4jBFWMRxlAXJUY2Q==",
-      "requires": {
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "@aws-sdk/util-hex-encoding": "3.310.0",
-        "@aws-sdk/util-middleware": "3.310.0",
-        "@aws-sdk/util-uri-escape": "3.310.0",
-        "@aws-sdk/util-utf8": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/smithy-client": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.310.0.tgz",
-      "integrity": "sha512-UHMFvhoB2RLzsTb0mQe1ofvBUg/+/JEu1uptavxf/hEpEKZnRAaHH5FNkTG+mbFd/olay/QFjqNcMD6t8LcsNQ==",
-      "requires": {
-        "@aws-sdk/middleware-stack": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
         }
       }
     },
     "@aws-sdk/token-providers": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.310.0.tgz",
-      "integrity": "sha512-G1JvB+2v8k900VJFkKVQXgLGF50ShOEIPxfK1gSQLkSU85vPwGIAANs1KvnlW08FsNbWp3+sKca4kfYKsooXMw==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.370.0.tgz",
+      "integrity": "sha512-EyR2ZYr+lJeRiZU2/eLR+mlYU9RXLQvNyGFSAekJKgN13Rpq/h0syzXVFLP/RSod/oZenh/fhVZ2HwlZxuGBtQ==",
       "requires": {
-        "@aws-sdk/client-sso-oidc": "3.310.0",
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/shared-ini-file-loader": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/client-sso-oidc": "3.370.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/property-provider": "^1.0.1",
+        "@smithy/shared-ini-file-loader": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
         "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
         }
       }
     },
     "@aws-sdk/types": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.310.0.tgz",
-      "integrity": "sha512-j8eamQJ7YcIhw7fneUfs8LYl3t01k4uHi4ZDmNRgtbmbmTTG3FZc2MotStZnp3nZB6vLiPF1o5aoJxWVvkzS6A==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.370.0.tgz",
+      "integrity": "sha512-8PGMKklSkRKjunFhzM2y5Jm0H2TBu7YRNISdYzXLUHKSP9zlMEYagseKVdmox0zKHf1LXVNuSlUV2b6SRrieCQ==",
       "requires": {
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
         "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/url-parser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.310.0.tgz",
-      "integrity": "sha512-mCLnCaSB9rQvAgx33u0DujLvr4d5yEm/W5r789GblwwQnlNXedVu50QRizMLTpltYWyAUoXjJgQnJHmJMaKXhw==",
-      "requires": {
-        "@aws-sdk/querystring-parser": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/util-base64": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
-      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
-      "requires": {
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/util-body-length-browser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
-      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
-      "requires": {
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/util-body-length-node": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
-      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
-      "requires": {
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/util-buffer-from": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
-      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
-      "requires": {
-        "@aws-sdk/is-array-buffer": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/util-config-provider": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
-      "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
-      "requires": {
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.310.0.tgz",
-      "integrity": "sha512-Mr2AoQsjAYNM5oAS2YJlYJqhiCvkFV/hu48slOZgbY4G7ueW4cM0DPkR16wqjcRCGqZ4JmAZB8Q5R0DMrLjhOQ==",
-      "requires": {
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.310.0.tgz",
-      "integrity": "sha512-JyBlvhQGR8w8NpFRZZXRVTDesafFKTu/gTWjcoxP7twa+fYHSIgPPFGnlcJ/iHaucjamSaWi5EQ+YQmnSZ8yHA==",
-      "requires": {
-        "@aws-sdk/config-resolver": "3.310.0",
-        "@aws-sdk/credential-provider-imds": "3.310.0",
-        "@aws-sdk/node-config-provider": "3.310.0",
-        "@aws-sdk/property-provider": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
         }
       }
     },
     "@aws-sdk/util-endpoints": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.310.0.tgz",
-      "integrity": "sha512-zG+/d/O5KPmAaeOMPd6bW1abifdT0H03f42keLjYEoRZzYtHPC5DuPE0UayiWGckI6BCDgy0sRKXCYS49UNFaQ==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.370.0.tgz",
+      "integrity": "sha512-5ltVAnM79nRlywwzZN5i8Jp4tk245OCGkKwwXbnDU+gq7zT3CIOsct1wNZvmpfZEPGt/bv7/NyRcjP+7XNsX/g==",
       "requires": {
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.370.0",
         "tslib": "^2.5.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/util-hex-encoding": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
-      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
-      "requires": {
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
         }
       }
     },
@@ -1150,105 +933,61 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/util-middleware": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.310.0.tgz",
-      "integrity": "sha512-FTSUKL/eRb9X6uEZClrTe27QFXUNNp7fxYrPndZwk1hlaOP5ix+MIHBcI7pIiiY/JPfOUmPyZOu+HetlFXjWog==",
-      "requires": {
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/util-retry": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.310.0.tgz",
-      "integrity": "sha512-FwWGhCBLfoivTMUHu1LIn4NjrN9JLJ/aX5aZmbcPIOhZVFJj638j0qDgZXyfvVqBuBZh7M8kGq0Oahy3dp69OA==",
-      "requires": {
-        "@aws-sdk/service-error-classification": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/util-uri-escape": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
-      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
-      "requires": {
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
         }
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.310.0.tgz",
-      "integrity": "sha512-yU/4QnHHuQ5z3vsUqMQVfYLbZGYwpYblPiuZx4Zo9+x0PBkNjYMqctdDcrpoH9Z2xZiDN16AmQGK1tix117ZKw==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.370.0.tgz",
+      "integrity": "sha512-028LxYZMQ0DANKhW+AKFQslkScZUeYlPmSphrCIXgdIItRZh6ZJHGzE7J/jDsEntZOrZJsjI4z0zZ5W2idj04w==",
       "requires": {
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/types": "^1.1.0",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       },
       "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
         "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
         }
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.310.0.tgz",
-      "integrity": "sha512-Ra3pEl+Gn2BpeE7KiDGpi4zj7WJXZA5GXnGo3mjbi9+Y3zrbuhJAbdZO3mO/o7xDgMC6ph4xCTbaSGzU6b6EDg==",
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.370.0.tgz",
+      "integrity": "sha512-33vxZUp8vxTT/DGYIR3PivQm07sSRGWI+4fCv63Rt7Q++fO24E0kQtmVAlikRY810I10poD6rwILVtITtFSzkg==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
+        "@aws-sdk/types": "3.370.0",
+        "@smithy/node-config-provider": "^1.0.1",
+        "@smithy/types": "^1.1.0",
         "tslib": "^2.5.0"
       },
       "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
         "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/util-utf8": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
-      "integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
-      "requires": {
-        "@aws-sdk/util-buffer-from": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
         }
       }
     },
@@ -1261,26 +1000,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
-      }
-    },
-    "@aws-sdk/util-waiter": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.310.0.tgz",
-      "integrity": "sha512-AV5j3guH/Y4REu+Qh3eXQU9igljHuU4XjX2sADAgf54C0kkhcCCkkiuzk3IsX089nyJCqIcj5idbjdvpnH88Vw==",
-      "requires": {
-        "@aws-sdk/abort-controller": "3.310.0",
-        "@aws-sdk/types": "3.310.0",
-        "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
         }
       }
     },
@@ -1720,6 +1442,1036 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
       "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
+    },
+    "@smithy/abort-controller": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.1.0.tgz",
+      "integrity": "sha512-5imgGUlZL4dW4YWdMYAKLmal9ny/tlenM81QZY7xYyb76z9Z/QOg7oM5Ak9HQl8QfFTlGVWwcMXl+54jroRgEQ==",
+      "requires": {
+        "@smithy/types": "^1.2.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/config-resolver": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-1.1.0.tgz",
+      "integrity": "sha512-7WD9eZHp46BxAjNGHJLmxhhyeiNWkBdVStd7SUJPUZqQGeIO/REtIrcIfKUfdiHTQ9jyu2SYoqvzqqaFc6987w==",
+      "requires": {
+        "@smithy/types": "^1.2.0",
+        "@smithy/util-config-provider": "^1.1.0",
+        "@smithy/util-middleware": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/credential-provider-imds": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-1.1.0.tgz",
+      "integrity": "sha512-kUMOdEu3RP6ozH0Ga8OeMP8gSkBsK1UqZZKyPLFnpZHrtZuHSSt7M7gsHYB/bYQBZAo3o7qrGmRty3BubYtYxQ==",
+      "requires": {
+        "@smithy/node-config-provider": "^1.1.0",
+        "@smithy/property-provider": "^1.2.0",
+        "@smithy/types": "^1.2.0",
+        "@smithy/url-parser": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/eventstream-codec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-1.1.0.tgz",
+      "integrity": "sha512-3tEbUb8t8an226jKB6V/Q2XU/J53lCwCzULuBPEaF4JjSh+FlCMp7TmogE/Aij5J9DwlsZ4VAD/IRDuQ/0ZtMw==",
+      "requires": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^1.2.0",
+        "@smithy/util-hex-encoding": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/eventstream-serde-browser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-1.1.0.tgz",
+      "integrity": "sha512-qUov6SYlcCeubwTQgaSBuNO0J31UdwgGRSZvmHhc3CCYOywoVSsA5vahcNuhoZDzZkhWTpol3Pm7+6OUuHF0aA==",
+      "requires": {
+        "@smithy/eventstream-serde-universal": "^1.1.0",
+        "@smithy/types": "^1.2.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/eventstream-serde-config-resolver": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-1.1.0.tgz",
+      "integrity": "sha512-vtPnp8FJkrNibWZCXvJN6rijTAEAzrmEKNfCUJOHAeBScY25hc6NjYlEJfdSmhW1qaA179oXeqHobcUNzvFkmw==",
+      "requires": {
+        "@smithy/types": "^1.2.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/eventstream-serde-node": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-1.1.0.tgz",
+      "integrity": "sha512-r8kUOPsJMolBGi/eU2gKfw5spfAhQjJXLe4bjjTzkapsqL654JZ+8G9iS1TprYUcCoCHDbwnH1of3kjrYKk7CQ==",
+      "requires": {
+        "@smithy/eventstream-serde-universal": "^1.1.0",
+        "@smithy/types": "^1.2.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/eventstream-serde-universal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-1.1.0.tgz",
+      "integrity": "sha512-8nQttgdbefJbLfz7Mao0FtkdRUlc92fCiHV3vClAl1N/qetm/I6Lsu5mLt9CzG7TGFkFb5t3qzAV2FaeAqF+ag==",
+      "requires": {
+        "@smithy/eventstream-codec": "^1.1.0",
+        "@smithy/types": "^1.2.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/fetch-http-handler": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-1.1.0.tgz",
+      "integrity": "sha512-N22C9R44u5WGlcY+Wuv8EXmCAq62wWwriRAuoczMEwAIjPbvHSthyPSLqI4S7kAST1j6niWg8kwpeJ3ReAv3xg==",
+      "requires": {
+        "@smithy/protocol-http": "^1.2.0",
+        "@smithy/querystring-builder": "^1.1.0",
+        "@smithy/types": "^1.2.0",
+        "@smithy/util-base64": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/protocol-http": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.2.0.tgz",
+          "integrity": "sha512-GfGfruksi3nXdFok5RhgtOnWe5f6BndzYfmEXISD+5gAGdayFGpjWu5pIqIweTudMtse20bGbc+7MFZXT1Tb8Q==",
+          "requires": {
+            "@smithy/types": "^1.2.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/querystring-builder": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.1.0.tgz",
+          "integrity": "sha512-gDEi4LxIGLbdfjrjiY45QNbuDmpkwh9DX4xzrR2AzjjXpxwGyfSpbJaYhXARw9p17VH0h9UewnNQXNwaQyYMDA==",
+          "requires": {
+            "@smithy/types": "^1.2.0",
+            "@smithy/util-uri-escape": "^1.1.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/util-uri-escape": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.1.0.tgz",
+          "integrity": "sha512-/jL/V1xdVRt5XppwiaEU8Etp5WHZj609n0xMTuehmCqdoOFbId1M+aEeDWZsQ+8JbEB/BJ6ynY2SlYmOaKtt8w==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/hash-node": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-1.1.0.tgz",
+      "integrity": "sha512-yiNKDGMzrQjnpnbLfkYKo+HwIxmBAsv0AI++QIJwvhfkLpUTBylelkv6oo78/YqZZS6h+bGfl0gILJsKE2wAKQ==",
+      "requires": {
+        "@smithy/types": "^1.2.0",
+        "@smithy/util-buffer-from": "^1.1.0",
+        "@smithy/util-utf8": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/invalid-dependency": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-1.1.0.tgz",
+      "integrity": "sha512-h2rXn68ClTwzPXYzEUNkz+0B/A0Hz8YdFNTiEwlxkwzkETGKMxmsrQGFXwYm3jd736R5vkXcClXz1ddKrsaBEQ==",
+      "requires": {
+        "@smithy/types": "^1.2.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/is-array-buffer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-1.1.0.tgz",
+      "integrity": "sha512-twpQ/n+3OWZJ7Z+xu43MJErmhB/WO/mMTnqR6PwWQShvSJ/emx5d1N59LQZk6ZpTAeuRWrc+eHhkzTp9NFjNRQ==",
+      "requires": {
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/middleware-content-length": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-1.1.0.tgz",
+      "integrity": "sha512-iNxwhZ7Xc5+LjeDElEOi/Nh8fFsc9Dw9+5w7h7/GLFIU0RgAwBJuJtcP1vNTOwzW4B3hG+gRu8sQLqA9OEaTwA==",
+      "requires": {
+        "@smithy/protocol-http": "^1.2.0",
+        "@smithy/types": "^1.2.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/protocol-http": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.2.0.tgz",
+          "integrity": "sha512-GfGfruksi3nXdFok5RhgtOnWe5f6BndzYfmEXISD+5gAGdayFGpjWu5pIqIweTudMtse20bGbc+7MFZXT1Tb8Q==",
+          "requires": {
+            "@smithy/types": "^1.2.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/middleware-endpoint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-1.1.0.tgz",
+      "integrity": "sha512-PvpazNjVpxX2ICrzoFYCpFnjB39DKCpZds8lRpAB3p6HGrx6QHBaNvOzVhJGBf0jcAbfCdc5/W0n9z8VWaSSww==",
+      "requires": {
+        "@smithy/middleware-serde": "^1.1.0",
+        "@smithy/types": "^1.2.0",
+        "@smithy/url-parser": "^1.1.0",
+        "@smithy/util-middleware": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/middleware-retry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-1.1.0.tgz",
+      "integrity": "sha512-lINKYxIvT+W20YFOtHBKeGm7npuJg0/YCoShttU7fVpsmU+a2rdb9zrJn1MHqWfUL6DhTAWGa0tH2O7l4XrDcw==",
+      "requires": {
+        "@smithy/protocol-http": "^1.2.0",
+        "@smithy/service-error-classification": "^1.1.0",
+        "@smithy/types": "^1.2.0",
+        "@smithy/util-middleware": "^1.1.0",
+        "@smithy/util-retry": "^1.1.0",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "@smithy/protocol-http": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.2.0.tgz",
+          "integrity": "sha512-GfGfruksi3nXdFok5RhgtOnWe5f6BndzYfmEXISD+5gAGdayFGpjWu5pIqIweTudMtse20bGbc+7MFZXT1Tb8Q==",
+          "requires": {
+            "@smithy/types": "^1.2.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/middleware-serde": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-1.1.0.tgz",
+      "integrity": "sha512-RiBMxhxuO9VTjHsjJvhzViyceoLhU6gtrnJGpAXY43wE49IstXIGEQz8MT50/hOq5EumX16FCpup0r5DVyfqNQ==",
+      "requires": {
+        "@smithy/types": "^1.2.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/middleware-stack": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-1.1.0.tgz",
+      "integrity": "sha512-XynYiIvXNea2BbLcppvpNK0zu8o2woJqgnmxqYTn4FWagH/Hr2QIk8LOsUz7BIJ4tooFhmx8urHKCdlPbbPDCA==",
+      "requires": {
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/node-config-provider": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-1.1.0.tgz",
+      "integrity": "sha512-2G4TlzUnmTrUY26VKTonQqydwb+gtM/mcl+TqDP8CnWtJKVL8ElPpKgLGScP04bPIRY9x2/10lDdoaRXDqPuCw==",
+      "requires": {
+        "@smithy/property-provider": "^1.2.0",
+        "@smithy/shared-ini-file-loader": "^1.1.0",
+        "@smithy/types": "^1.2.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/node-http-handler": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.1.0.tgz",
+      "integrity": "sha512-d3kRriEgaIiGXLziAM8bjnaLn1fthCJeTLZIwEIpzQqe6yPX0a+yQoLCTyjb2fvdLwkMoG4p7THIIB5cj5lkbg==",
+      "requires": {
+        "@smithy/abort-controller": "^1.1.0",
+        "@smithy/protocol-http": "^1.2.0",
+        "@smithy/querystring-builder": "^1.1.0",
+        "@smithy/types": "^1.2.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/property-provider": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-1.2.0.tgz",
+      "integrity": "sha512-qlJd9gT751i4T0t/hJAyNGfESfi08Fek8QiLcysoKPgR05qHhG0OYhlaCJHhpXy4ECW0lHyjvFM1smrCLIXVfw==",
+      "requires": {
+        "@smithy/types": "^1.2.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/protocol-http": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.2.0.tgz",
+      "integrity": "sha512-GfGfruksi3nXdFok5RhgtOnWe5f6BndzYfmEXISD+5gAGdayFGpjWu5pIqIweTudMtse20bGbc+7MFZXT1Tb8Q==",
+      "requires": {
+        "@smithy/types": "^1.2.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/querystring-builder": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.1.0.tgz",
+      "integrity": "sha512-gDEi4LxIGLbdfjrjiY45QNbuDmpkwh9DX4xzrR2AzjjXpxwGyfSpbJaYhXARw9p17VH0h9UewnNQXNwaQyYMDA==",
+      "requires": {
+        "@smithy/types": "^1.2.0",
+        "@smithy/util-uri-escape": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/querystring-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-1.1.0.tgz",
+      "integrity": "sha512-Lm/FZu2qW3XX+kZ4WPwr+7aAeHf1Lm84UjNkKyBu16XbmEV7ukfhXni2aIwS2rcVf8Yv5E7wchGGpOFldj9V4Q==",
+      "requires": {
+        "@smithy/types": "^1.2.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/service-error-classification": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-1.1.0.tgz",
+      "integrity": "sha512-OCTEeJ1igatd5kFrS2VDlYbainNNpf7Lj1siFOxnRWqYOP9oNvC5HOJBd3t+Z8MbrmehBtuDJ2QqeBsfeiNkww=="
+    },
+    "@smithy/shared-ini-file-loader": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-1.1.0.tgz",
+      "integrity": "sha512-S/v33zvCWzFyGZGlsEF0XsZtNNR281UhR7byk3nRfsgw5lGpg51rK/zjMgulM+h6NSuXaFILaYrw1I1v4kMcuA==",
+      "requires": {
+        "@smithy/types": "^1.2.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/signature-v4": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-1.1.0.tgz",
+      "integrity": "sha512-fDo3m7YqXBs7neciOePPd/X9LPm5QLlDMdIC4m1H6dgNLnXfLMFNIxEfPyohGA8VW9Wn4X8lygnPSGxDZSmp0Q==",
+      "requires": {
+        "@smithy/eventstream-codec": "^1.1.0",
+        "@smithy/is-array-buffer": "^1.1.0",
+        "@smithy/types": "^1.2.0",
+        "@smithy/util-hex-encoding": "^1.1.0",
+        "@smithy/util-middleware": "^1.1.0",
+        "@smithy/util-uri-escape": "^1.1.0",
+        "@smithy/util-utf8": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/util-uri-escape": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.1.0.tgz",
+          "integrity": "sha512-/jL/V1xdVRt5XppwiaEU8Etp5WHZj609n0xMTuehmCqdoOFbId1M+aEeDWZsQ+8JbEB/BJ6ynY2SlYmOaKtt8w==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/smithy-client": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-1.1.0.tgz",
+      "integrity": "sha512-j32SGgVhv2G9nBTmel9u3OXux8KG20ssxuFakJrEeDug3kqbl1qrGzVLCe+Eib402UDtA0Sp1a4NZ2SEXDBxag==",
+      "requires": {
+        "@smithy/middleware-stack": "^1.1.0",
+        "@smithy/types": "^1.2.0",
+        "@smithy/util-stream": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "requires": {
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/url-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-1.1.0.tgz",
+      "integrity": "sha512-tpvi761kzboiLNGEWczuybMPCJh6WHB3cz9gWAG95mSyaKXmmX8ZcMxoV+irZfxDqLwZVJ22XTumu32S7Ow8aQ==",
+      "requires": {
+        "@smithy/querystring-parser": "^1.1.0",
+        "@smithy/types": "^1.2.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/util-base64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-1.1.0.tgz",
+      "integrity": "sha512-FpYmDmVbOXAxqvoVCwqehUN0zXS+lN8V7VS9O7I8MKeVHdSTsZzlwiMEvGoyTNOXWn8luF4CTDYgNHnZViR30g==",
+      "requires": {
+        "@smithy/util-buffer-from": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/util-body-length-browser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-1.1.0.tgz",
+      "integrity": "sha512-cep3ioRxzRZ2Jbp3Kly7gy6iNVefYXiT6ETt8W01RQr3uwi1YMkrbU1p3lMR4KhX/91Nrk6UOgX1RH+oIt48RQ==",
+      "requires": {
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/util-body-length-node": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-1.1.0.tgz",
+      "integrity": "sha512-fRHRjkUuT5em4HZoshySXmB1n3HAU7IS232s+qU4TicexhyGJpXMK/2+c56ePOIa1FOK2tV1Q3J/7Mae35QVSw==",
+      "requires": {
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/util-buffer-from": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-1.1.0.tgz",
+      "integrity": "sha512-9m6NXE0ww+ra5HKHCHig20T+FAwxBAm7DIdwc/767uGWbRcY720ybgPacQNB96JMOI7xVr/CDa3oMzKmW4a+kw==",
+      "requires": {
+        "@smithy/is-array-buffer": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/util-config-provider": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-1.1.0.tgz",
+      "integrity": "sha512-rQ47YpNmF6Is4I9GiE3T3+0xQ+r7RKRKbmHYyGSbyep/0cSf9kteKcI0ssJTvveJ1K4QvwrxXj1tEFp/G2UqxQ==",
+      "requires": {
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/util-defaults-mode-browser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-1.1.0.tgz",
+      "integrity": "sha512-0bWhs1e412bfC5gwPCMe8Zbz0J8UoZ/meEQdo6MYj8Ne+c+QZ+KxVjx0a1dFYOclvM33SslL9dP0odn8kfblkg==",
+      "requires": {
+        "@smithy/property-provider": "^1.2.0",
+        "@smithy/types": "^1.2.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/util-defaults-mode-node": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-1.1.0.tgz",
+      "integrity": "sha512-440e25TUH2b+TeK5CwsjYFrI9ShVOgA31CoxCKiv4ncSK4ZM68XW5opYxQmzMbRWARGEMu2XEUeBmOgMU2RLsw==",
+      "requires": {
+        "@smithy/config-resolver": "^1.1.0",
+        "@smithy/credential-provider-imds": "^1.1.0",
+        "@smithy/node-config-provider": "^1.1.0",
+        "@smithy/property-provider": "^1.2.0",
+        "@smithy/types": "^1.2.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/util-hex-encoding": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-1.1.0.tgz",
+      "integrity": "sha512-7UtIE9eH0u41zpB60Jzr0oNCQ3hMJUabMcKRUVjmyHTXiWDE4vjSqN6qlih7rCNeKGbioS7f/y2Jgym4QZcKFg==",
+      "requires": {
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/util-middleware": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-1.1.0.tgz",
+      "integrity": "sha512-6hhckcBqVgjWAqLy2vqlPZ3rfxLDhFWEmM7oLh2POGvsi7j0tHkbN7w4DFhuBExVJAbJ/qqxqZdRY6Fu7/OezQ==",
+      "requires": {
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/util-retry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-1.1.0.tgz",
+      "integrity": "sha512-ygQW5HBqYXpR3ua09UciS0sL7UGJzGiktrKkOuEJwARoUuzz40yaEGU6xd9Gs7KBmAaFC8gMfnghHtwZ2nyBCQ==",
+      "requires": {
+        "@smithy/service-error-classification": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/util-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-1.1.0.tgz",
+      "integrity": "sha512-w3lsdGsntaLQIrwDWJkIFKrFscgZXwU/oxsse09aSTNv5TckPhDeYea3LhsDrU5MGAG3vprhVZAKr33S45coVA==",
+      "requires": {
+        "@smithy/fetch-http-handler": "^1.1.0",
+        "@smithy/node-http-handler": "^1.1.0",
+        "@smithy/types": "^1.2.0",
+        "@smithy/util-base64": "^1.1.0",
+        "@smithy/util-buffer-from": "^1.1.0",
+        "@smithy/util-hex-encoding": "^1.1.0",
+        "@smithy/util-utf8": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/abort-controller": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.1.0.tgz",
+          "integrity": "sha512-5imgGUlZL4dW4YWdMYAKLmal9ny/tlenM81QZY7xYyb76z9Z/QOg7oM5Ak9HQl8QfFTlGVWwcMXl+54jroRgEQ==",
+          "requires": {
+            "@smithy/types": "^1.2.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/node-http-handler": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-1.1.0.tgz",
+          "integrity": "sha512-d3kRriEgaIiGXLziAM8bjnaLn1fthCJeTLZIwEIpzQqe6yPX0a+yQoLCTyjb2fvdLwkMoG4p7THIIB5cj5lkbg==",
+          "requires": {
+            "@smithy/abort-controller": "^1.1.0",
+            "@smithy/protocol-http": "^1.2.0",
+            "@smithy/querystring-builder": "^1.1.0",
+            "@smithy/types": "^1.2.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/protocol-http": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.2.0.tgz",
+          "integrity": "sha512-GfGfruksi3nXdFok5RhgtOnWe5f6BndzYfmEXISD+5gAGdayFGpjWu5pIqIweTudMtse20bGbc+7MFZXT1Tb8Q==",
+          "requires": {
+            "@smithy/types": "^1.2.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/querystring-builder": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-1.1.0.tgz",
+          "integrity": "sha512-gDEi4LxIGLbdfjrjiY45QNbuDmpkwh9DX4xzrR2AzjjXpxwGyfSpbJaYhXARw9p17VH0h9UewnNQXNwaQyYMDA==",
+          "requires": {
+            "@smithy/types": "^1.2.0",
+            "@smithy/util-uri-escape": "^1.1.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/util-uri-escape": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.1.0.tgz",
+          "integrity": "sha512-/jL/V1xdVRt5XppwiaEU8Etp5WHZj609n0xMTuehmCqdoOFbId1M+aEeDWZsQ+8JbEB/BJ6ynY2SlYmOaKtt8w==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/util-uri-escape": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-1.1.0.tgz",
+      "integrity": "sha512-/jL/V1xdVRt5XppwiaEU8Etp5WHZj609n0xMTuehmCqdoOFbId1M+aEeDWZsQ+8JbEB/BJ6ynY2SlYmOaKtt8w==",
+      "requires": {
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/util-utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-1.1.0.tgz",
+      "integrity": "sha512-p/MYV+JmqmPyjdgyN2UxAeYDj9cBqCjp0C/NsTWnnjoZUVqoeZ6IrW915L9CAKWVECgv9lVQGc4u/yz26/bI1A==",
+      "requires": {
+        "@smithy/util-buffer-from": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
+    },
+    "@smithy/util-waiter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-1.1.0.tgz",
+      "integrity": "sha512-S6FNIB3UJT+5Efd/0DeziO5Rs82QAMODHW4v2V3oNRrwaBigY/7Yx3SiLudZuF9WpVsV08Ih3BjIH34nzZiinQ==",
+      "requires": {
+        "@smithy/abort-controller": "^1.1.0",
+        "@smithy/types": "^1.2.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@smithy/abort-controller": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-1.1.0.tgz",
+          "integrity": "sha512-5imgGUlZL4dW4YWdMYAKLmal9ny/tlenM81QZY7xYyb76z9Z/QOg7oM5Ak9HQl8QfFTlGVWwcMXl+54jroRgEQ==",
+          "requires": {
+            "@smithy/types": "^1.2.0",
+            "tslib": "^2.5.0"
+          }
+        },
+        "@smithy/types": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+          "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        },
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
+      }
     },
     "@types/color-name": {
       "version": "1.1.1",
@@ -2479,9 +3231,9 @@
       "dev": true
     },
     "fast-xml-parser": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
-      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
       "requires": {
         "strnum": "^1.0.5"
       }
@@ -4011,6 +4763,11 @@
           "dev": true
         }
       }
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "which": {
       "version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@babbel/miza-kinesis",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babbel/miza-kinesis",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Library to emit Events to Kinesis Events Queue",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "build": "rm -rf node_modules && npm install --production"
   },
   "dependencies": {
-    "@aws-sdk/client-kinesis": "^3.312.0",
-    "@aws-sdk/node-http-handler": "^3.310.0",
+    "@aws-sdk/client-kinesis": "^3.370.0",
+    "@smithy/node-http-handler": "^1.1.0",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/src/kinesis.js
+++ b/src/kinesis.js
@@ -1,5 +1,5 @@
 const { KinesisClient } = require("@aws-sdk/client-kinesis");
-const { NodeHttpHandler } = require("@aws-sdk/node-http-handler");
+const { NodeHttpHandler } = require("@smithy/node-http-handler");
 
 module.exports = ({
   region,

--- a/test/integrations/kinesis_helper.js
+++ b/test/integrations/kinesis_helper.js
@@ -4,7 +4,7 @@ const {
   GetRecordsCommand,
   KinesisClient,
 } = require("@aws-sdk/client-kinesis");
-const { NodeHttpHandler } = require("@aws-sdk/node-http-handler");
+const { NodeHttpHandler } = require("@smithy/node-http-handler");
 
 const streamARN = "arn:aws:kinesis:eu-west-1:000000000000:stream/kinesis-test";
 const localKinesisEndpoint = "http://localhost:4567";

--- a/test/unit/kinesis.test.js
+++ b/test/unit/kinesis.test.js
@@ -1,5 +1,5 @@
 const { KinesisClient } = require("@aws-sdk/client-kinesis");
-const { NodeHttpHandler } = require("@aws-sdk/node-http-handler");
+const { NodeHttpHandler } = require("@smithy/node-http-handler");
 
 const instantiateKinesis = require("../../src/kinesis");
 


### PR DESCRIPTION
#### Description of change

- `@aws-sdk/node-http-handler` is now deprecated and is replaced with `@smithy/node-http-handler`
- Updated `@aws-sdk/client-kinesis`

#### Checklist

- [x] TypeScript definitions are up-to-date
