### PR TITLE
Validate URL-based Kinesis ARN 🛠

### DIFF
--- a/src/arnParser.js
+++ b/src/arnParser.js
@@ -1,4 +1,4 @@
-const ARN_VALIDATOR = /^arn:aws:kinesis:([a-z\-0-9]+):(\d+):stream\/(.+)$/;
+const ARN_VALIDATOR = /^arn:aws:kinesis:([a-z\-0-9]+):([a-zA-Z0-9:\/]+):stream\/(.+)$/;
 
 const parse = (arn) => {
   const match = arn.match(ARN_VALIDATOR);

--- a/src/arnParser.js
+++ b/src/arnParser.js
@@ -1,5 +1,5 @@
 const ARN_VALIDATOR =
-  /^arn:aws:kinesis:([a-z\-0-9]+):((http(s):\/\/.)[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)|(\d+)):stream\/(.+)$/;
+  /^arn:aws:kinesis:([a-z\-0-9]+):(?:(?:http(?:s):\/\/.)[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b(?:[-a-zA-Z0-9@:%_\+.~#?&//=]*)|(?:\d+)):stream\/(.+)$/;
 
 const parse = (arn) => {
   const match = arn.match(ARN_VALIDATOR);
@@ -7,7 +7,7 @@ const parse = (arn) => {
 
   return {
     region: match[1],
-    resource: match[3],
+    resource: match[2],
   };
 };
 

--- a/src/arnParser.js
+++ b/src/arnParser.js
@@ -1,4 +1,4 @@
-const ARN_VALIDATOR = /^arn:aws:kinesis:([a-z\-0-9]+):([a-zA-Z0-9:\/]+):stream\/(.+)$/;
+const ARN_VALIDATOR = /^arn:aws:kinesis:([a-z\-0-9]+):((http(s):\/\/.)[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)|(\d+)):stream\/(.+)$/;
 
 const parse = (arn) => {
   const match = arn.match(ARN_VALIDATOR);

--- a/src/arnParser.js
+++ b/src/arnParser.js
@@ -1,4 +1,5 @@
-const ARN_VALIDATOR = /^arn:aws:kinesis:([a-z\-0-9]+):((http(s):\/\/.)[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)|(\d+)):stream\/(.+)$/;
+const ARN_VALIDATOR =
+  /^arn:aws:kinesis:([a-z\-0-9]+):((http(s):\/\/.)[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)|(\d+)):stream\/(.+)$/;
 
 const parse = (arn) => {
   const match = arn.match(ARN_VALIDATOR);


### PR DESCRIPTION
## Description

Hey there, maintainers of miza-kinesis! 👋🏼

While refactoring a lambda function, we installed `miza-kinesis` to facilitate the emission of a new event from this lambda function into a kinesis stream. 🚰

We found that the current [ARN validation logic](https://github.com/babbel/miza-kinesis/blob/2a5dc92997166ec7dfe780e37548316f3f3d9c4d/src/arnParser.js#L1) of this library may not be compatible with the ARN that we are referencing to use the [CreateStream](https://docs.localstack.cloud/user-guide/aws/kinesis/#create-a-kinesis-stream) API with LocalStack; specifically we'd like for our ARN, **which consists of a URL instead of an `account_id`**, to also pass the validation.

## Checklist 
- [x] TypeScript definitions are up-to-date
